### PR TITLE
fix: make metadata trait methods callable statically

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -358,7 +358,7 @@ foreach ($fields as $field) {
 }
 
 // Get picklist values
-$industryOptions = Account::getPicklistValues('Industry');
+$industryOptions = Account::picklistValues('Industry');
 
 foreach ($industryOptions as $option) {
     echo "{$option['label']} => {$option['value']}\n";

--- a/src/Models/Concerns/HasSalesforceMetadata.php
+++ b/src/Models/Concerns/HasSalesforceMetadata.php
@@ -11,35 +11,49 @@ trait HasSalesforceMetadata
     /**
      * Get picklist values for a specific field on this model
      *
+     * Can be called statically or on an instance:
+     *   Account::picklistValues('Industry')
+     *   $account->picklistValues('Industry')
+     *
      * @param  string  $field  Field name
      * @return array Array of picklist values with 'value' and 'label' keys
      */
-    public function picklistValues(string $field): array
+    public static function picklistValues(string $field): array
     {
-        $adapter = $this->getSalesforceAdapter();
+        $instance = new static;
+        $adapter = $instance->getSalesforceAdapter();
 
-        return $adapter->picklistValues($this->getTable(), $field);
+        return $adapter->picklistValues($instance->getTable(), $field);
     }
 
     /**
      * Get the describe metadata for this model's Salesforce object
+     *
+     * Can be called statically or on an instance:
+     *   Account::describe()
+     *   $account->describe()
      */
-    public function describe(): array
+    public static function describe(): array
     {
-        $adapter = $this->getSalesforceAdapter();
+        $instance = new static;
+        $adapter = $instance->getSalesforceAdapter();
 
-        return $adapter->describe($this->getTable());
+        return $adapter->describe($instance->getTable());
     }
 
     /**
      * Get metadata for a specific field
      *
+     * Can be called statically or on an instance:
+     *   Account::fieldMetadata('Name')
+     *   $account->fieldMetadata('Name')
+     *
      * @param  string  $field  Field name
      * @return array|null Field metadata or null if not found
      */
-    public function fieldMetadata(string $field): ?array
+    public static function fieldMetadata(string $field): ?array
     {
-        $metadata = $this->describe();
+        $metadata = static::describe();
 
         return collect($metadata['fields'] ?? [])->firstWhere('name', $field);
     }

--- a/tests/Unit/HasSalesforceMetadataTest.php
+++ b/tests/Unit/HasSalesforceMetadataTest.php
@@ -49,6 +49,23 @@ describe('HasSalesforceMetadata', function () {
 
             expect($result)->toBe([]);
         });
+
+        it('can be called statically', function () {
+            $expected = [
+                ['value' => 'Technology', 'label' => 'Technology'],
+                ['value' => 'Finance', 'label' => 'Finance'],
+            ];
+
+            $this->mockAdapter
+                ->shouldReceive('picklistValues')
+                ->once()
+                ->with('Account', 'Industry')
+                ->andReturn($expected);
+
+            $result = Account::picklistValues('Industry');
+
+            expect($result)->toBe($expected);
+        });
     });
 
     describe('describe()', function () {
@@ -89,6 +106,26 @@ describe('HasSalesforceMetadata', function () {
             $result = $this->account->describe();
 
             expect($result)->toHaveKeys(['name', 'label', 'fields', 'recordTypes']);
+        });
+
+        it('can be called statically', function () {
+            $expected = [
+                'name'   => 'Account',
+                'fields' => [
+                    ['name' => 'Id', 'type' => 'id'],
+                    ['name' => 'Name', 'type' => 'string'],
+                ],
+            ];
+
+            $this->mockAdapter
+                ->shouldReceive('describe')
+                ->once()
+                ->with('Account')
+                ->andReturn($expected);
+
+            $result = Account::describe();
+
+            expect($result)->toBe($expected);
         });
     });
 
@@ -165,6 +202,23 @@ describe('HasSalesforceMetadata', function () {
             $result = $this->account->fieldMetadata('Name');
 
             expect($result)->toBe($first);
+        });
+
+        it('can be called statically', function () {
+            $this->mockAdapter
+                ->shouldReceive('describe')
+                ->once()
+                ->with('Account')
+                ->andReturn([
+                    'fields' => [
+                        ['name' => 'Id', 'type' => 'id', 'label' => 'Account ID'],
+                        ['name' => 'Name', 'type' => 'string', 'label' => 'Account Name'],
+                    ],
+                ]);
+
+            $result = Account::fieldMetadata('Name');
+
+            expect($result)->toBe(['name' => 'Name', 'type' => 'string', 'label' => 'Account Name']);
         });
     });
 });


### PR DESCRIPTION
## Summary
- Made `describe()`, `picklistValues()`, and `fieldMetadata()` on `HasSalesforceMetadata` trait callable statically (e.g. `Account::describe()`)
- Fixed docs referencing non-existent `Account::getPicklistValues()` → `Account::picklistValues()`
- Added 3 tests covering static calling for all metadata trait methods

## Test plan
- [x] All 474 tests pass
- [x] Static calls (`Account::describe()`, `Account::picklistValues()`, `Account::fieldMetadata()`) verified via new tests
- [x] Instance calls continue to work (existing tests unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)