### PR TITLE
feat(auth): single-flight lock + retry on transient Salesforce OAuth failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to `eloquent-salesforce-objects` will be documented in this file.
 
+## v1.1.0 - 2026-05-22
+
+### Added
+
+- **Authentication resilience layer in `AuthenticationManager`** — fixes a production failure mode where concurrent workers all hammered the Salesforce OAuth endpoint after a token-cache miss, triggering 400 `unknown_error / retry your request` responses from Salesforce.
+    - **Single-flight cache lock** — only one worker authenticates at a time. Concurrent callers block on a Laravel `Cache::lock(...)` and read the freshly-cached token via a double-check, instead of each issuing an independent `POST /services/oauth2/token`.
+    - **Selective retry with backoff and jitter** — transient failures (Salesforce's documented `unknown_error / retry your request` envelope, HTTP 5xx, and Guzzle `ConnectException`) are retried with exponential backoff plus jitter. Permanent failures (`invalid_grant`, credential/config errors, other 4xx) fail fast and are **not** retried.
+    - **Lock key scoped per connected app** — uses `sha1(consumer_key)` so multi-org setups don't collide on a shared lock.
+    - **`LockTimeoutException`** surfaces as `AuthenticationException` with a clear message.
+
+### Configuration
+
+New `authentication` block in `config/eloquent-salesforce-objects.php`. All keys are env-tunable. Existing installations work without changes — defaults are conservative.
+
+| Key | Default | Env var |
+|-----|---------|---------|
+| `authentication.retry_attempts` | `3` | `SALESFORCE_AUTH_RETRY_ATTEMPTS` |
+| `authentication.retry_base_delay_ms` | `250` | `SALESFORCE_AUTH_RETRY_BASE_DELAY_MS` |
+| `authentication.lock_wait_seconds` | `8` | `SALESFORCE_AUTH_LOCK_WAIT_SECONDS` |
+| `authentication.lock_ttl_seconds` | `10` | `SALESFORCE_AUTH_LOCK_TTL_SECONDS` |
+
+### Upgrade Notes
+
+- **No breaking API changes.** The public surface of `AuthenticationManager` is unchanged.
+- **Republish config to pick up the new keys** (optional — defaults work without it):
+    ```bash
+    php artisan vendor:publish --tag="eloquent-salesforce-objects-config" --force
+    ```
+- **Concurrency note** — on cache miss, `Forrest::hasToken()` is now called twice (outer fast-path + double-check inside the lock). Tests that mocked `hasToken()` with `->once()` for the cache-miss path need to be updated to `->twice()`. The hot path (token already cached) is unchanged: still a single `hasToken()` call.
+
 ## v1.0.3 - 2026-04-23
 
 ### Fixed

--- a/config/eloquent-salesforce-objects.php
+++ b/config/eloquent-salesforce-objects.php
@@ -44,6 +44,35 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Authentication Resilience
+    |--------------------------------------------------------------------------
+    |
+    | Controls how the package handles Salesforce OAuth authentication under
+    | concurrency and transient failures.
+    |
+    | 'retry_attempts'      - Total attempts (including the first) when calling
+    |                         the OAuth endpoint. Only retries on transient signals:
+    |                         connection errors, HTTP 5xx, and Salesforce's
+    |                         documented 400 "unknown_error / retry your request".
+    |                         Permanent errors (invalid_grant, bad credentials)
+    |                         are never retried.
+    | 'retry_base_delay_ms' - Base delay between attempts in milliseconds.
+    |                         Backoff is exponential with jitter.
+    | 'lock_wait_seconds'   - How long a worker will wait to acquire the
+    |                         single-flight authentication lock.
+    | 'lock_ttl_seconds'    - Maximum time the lock is held. Should comfortably
+    |                         exceed worst-case OAuth round-trip + retries.
+    |
+    */
+    'authentication' => [
+        'retry_attempts'      => env('SALESFORCE_AUTH_RETRY_ATTEMPTS', 3),
+        'retry_base_delay_ms' => env('SALESFORCE_AUTH_RETRY_BASE_DELAY_MS', 250),
+        'lock_wait_seconds'   => env('SALESFORCE_AUTH_LOCK_WAIT_SECONDS', 8),
+        'lock_ttl_seconds'    => env('SALESFORCE_AUTH_LOCK_TTL_SECONDS', 10),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Metadata Cache TTL
     |--------------------------------------------------------------------------
     |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,30 @@ Creates `config/eloquent-salesforce-objects.php`.
 | `log_level` | `error` | Log level for Salesforce errors |
 | `enable_query_log` | `false` | Log all SOQL queries (useful for debugging) |
 
+### Authentication Resilience
+
+Controls how the package handles Salesforce OAuth authentication under concurrency and transient failures. Defaults are safe for most apps; tune these only if you see auth-related issues.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `authentication.retry_attempts` | `3` | Total OAuth attempts (incl. first). Only retries on transient errors. |
+| `authentication.retry_base_delay_ms` | `250` | Base delay between retries (ms). Backoff is exponential + jitter. |
+| `authentication.lock_wait_seconds` | `8` | How long a worker waits to acquire the single-flight auth lock. |
+| `authentication.lock_ttl_seconds` | `10` | Max time the auth lock is held. |
+
+**What gets retried:**
+
+- Salesforce's `400 { "error": "unknown_error", "error_description": "retry your request" }` (Salesforce-side transient throttle on the OAuth endpoint).
+- HTTP 5xx responses.
+- Network/TLS errors (`GuzzleHttp\Exception\ConnectException`).
+
+**What never gets retried:**
+
+- `invalid_grant`, `invalid_client_id`, `authentication failure` — credential/config issues. Retrying makes the problem worse.
+- All other 4xx responses.
+
+**Why the lock exists:** without it, if many workers (e.g. Horizon queue workers) hit a cache miss simultaneously, they would all `POST /services/oauth2/token` in parallel. Salesforce throttles concurrent OAuth requests for the same connected app + user, which produces the `unknown_error / retry your request` failure described above. The lock collapses the herd: one worker authenticates, the rest read the freshly-cached token.
+
 ### Other
 
 | Key | Default | Description |
@@ -76,6 +100,12 @@ SALESFORCE_THROW_EXCEPTIONS=true
 SALESFORCE_LOG_CHANNEL=
 SALESFORCE_LOG_LEVEL=error
 SALESFORCE_QUERY_LOG=false
+
+# Authentication Resilience
+SALESFORCE_AUTH_RETRY_ATTEMPTS=3
+SALESFORCE_AUTH_RETRY_BASE_DELAY_MS=250
+SALESFORCE_AUTH_LOCK_WAIT_SECONDS=8
+SALESFORCE_AUTH_LOCK_TTL_SECONDS=10
 ```
 
 **Tip:** Use `SALESFORCE_THROW_EXCEPTIONS=true` in development and `false` in production for graceful degradation.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,6 +46,29 @@ Solutions to common issues when working with Eloquent Salesforce Objects.
    - User profile must have "API Enabled" permission
    - Check in Salesforce: Setup → Users → User → Profile → System Permissions
 
+### "unknown_error / retry your request" 400 from `/services/oauth2/token`
+
+**Problem:** Production logs show repeated 400 responses from `POST https://login.salesforce.com/services/oauth2/token`:
+
+```
+{"error":"unknown_error","error_description":"retry your request"}
+```
+
+**What it means:** This is Salesforce's documented transient envelope on the OAuth endpoint. It's *not* a credentials problem (that would be `invalid_grant`). The two common causes are:
+
+1. **Concurrent OAuth calls from your app** — many workers cache-miss simultaneously and all POST to the token endpoint at once. Salesforce throttles concurrent requests for the same connected app + user.
+2. **Another app sharing the same connected app / username** — e.g. an admin running `sfdx`, a Zapier integration, the old portal — competes for token issuance and triggers the same throttle.
+
+**Solutions:**
+
+1. **Upgrade to v1.1.0+** — this package now adds a single-flight lock + selective retry around `Forrest::authenticate()`. The lock collapses concurrent token requests into one OAuth call, and the retry absorbs Salesforce's transient blips. See [Authentication Resilience](configuration.md#authentication-resilience).
+
+2. **Check Salesforce Login History** — Setup → Identity → Login History, filtered by your connected app. If you see attempts from IPs/clients you don't recognize, another app is sharing your credentials.
+
+3. **Use a dedicated Salesforce integration user per app** — separate username (and ideally separate connected app) for each application. Eliminates cross-app contention on the OAuth endpoint and is Salesforce's recommended pattern.
+
+4. **Tune retry config if needed** — for very chatty workloads, increase `SALESFORCE_AUTH_RETRY_ATTEMPTS` or `SALESFORCE_AUTH_RETRY_BASE_DELAY_MS`. Defaults work for most apps.
+
 ### "Invalid Grant" Error
 
 **Problem:** OAuth authentication fails with "invalid grant".

--- a/src/Support/AuthenticationManager.php
+++ b/src/Support/AuthenticationManager.php
@@ -5,17 +5,22 @@ declare(strict_types=1);
 namespace Daikazu\EloquentSalesforceObjects\Support;
 
 use Daikazu\EloquentSalesforceObjects\Exceptions\AuthenticationException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Support\Facades\Cache;
 use Omniphx\Forrest\Providers\Laravel\Facades\Forrest;
 use Throwable;
 
 class AuthenticationManager
 {
     /**
-     * Ensure valid Salesforce authentication exists
+     * Ensure valid Salesforce authentication exists.
      *
-     * Checks for existing valid token and authenticates if necessary.
+     * Uses a single-flight cache lock so concurrent workers don't all
+     * hammer the Salesforce OAuth endpoint when the token cache misses.
      *
-     * @throws AuthenticationException If authentication fails
+     * @throws AuthenticationException
      */
     public function ensureAuthenticated(): void
     {
@@ -23,23 +28,44 @@ class AuthenticationManager
             return;
         }
 
-        $this->authenticate();
+        try {
+            Cache::lock($this->lockKey(), $this->lockTtlSeconds())
+                ->block($this->lockWaitSeconds(), function (): void {
+                    // Double-check: another worker may have authenticated
+                    // while we were waiting for the lock.
+                    if (Forrest::hasToken()) {
+                        return;
+                    }
+
+                    $this->performAuthentication();
+                });
+        } catch (AuthenticationException $e) {
+            throw $e;
+        } catch (LockTimeoutException $e) {
+            throw new AuthenticationException(
+                'Timed out waiting for Salesforce authentication lock',
+                $e
+            );
+        }
     }
 
     /**
-     * Force fresh authentication bypassing token cache
+     * Force fresh authentication, bypassing the token cache check.
      *
-     * @throws AuthenticationException If authentication fails
+     * Intended for callers that have already determined the current
+     * token is invalid (e.g. INVALID_SESSION_ID on an API call).
+     *
+     * @throws AuthenticationException
      */
     public function forceReauthenticate(): void
     {
-        $this->authenticate();
+        $this->performAuthentication();
     }
 
     /**
-     * Get current Salesforce instance URL
+     * Get the current Salesforce instance URL.
      *
-     * @throws AuthenticationException If no valid token or instance URL available
+     * @throws AuthenticationException
      */
     public function getInstanceUrl(): string
     {
@@ -66,19 +92,119 @@ class AuthenticationManager
     }
 
     /**
-     * Perform actual authentication with Salesforce
+     * Call Forrest::authenticate() with retry on transient failures.
      *
-     * @throws AuthenticationException If authentication fails
+     * @throws AuthenticationException
      */
-    protected function authenticate(): void
+    protected function performAuthentication(): void
     {
-        try {
-            Forrest::authenticate();
-        } catch (Throwable $e) {
-            throw new AuthenticationException(
-                'Failed to authenticate with Salesforce: ' . $e->getMessage(),
-                $e
-            );
+        $maxAttempts = max(1, $this->retryAttempts());
+        $baseDelayMs = max(0, $this->retryBaseDelayMs());
+
+        $lastException = null;
+
+        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+            try {
+                Forrest::authenticate();
+
+                return;
+            } catch (Throwable $e) {
+                $lastException = $e;
+
+                if ($attempt >= $maxAttempts || ! $this->isRetryable($e)) {
+                    break;
+                }
+
+                $this->sleepBetweenAttempts($attempt, $baseDelayMs);
+            }
         }
+
+        throw new AuthenticationException(
+            'Failed to authenticate with Salesforce: ' . $lastException->getMessage(),
+            $lastException
+        );
+    }
+
+    /**
+     * Decide whether an authentication failure is worth retrying.
+     *
+     * Retry on:
+     *  - Connection errors (network/TLS blips)
+     *  - HTTP 5xx responses
+     *  - Salesforce's documented transient envelope:
+     *    400 { "error": "unknown_error", "error_description": "retry your request" }
+     *
+     * Do NOT retry on:
+     *  - invalid_grant, invalid_client_id, authentication failure
+     *    (credential / configuration problems — retrying makes it worse)
+     *  - Any other 4xx or unrecognised error
+     */
+    protected function isRetryable(Throwable $e): bool
+    {
+        if ($e instanceof ConnectException) {
+            return true;
+        }
+
+        if ($e instanceof RequestException && $e->hasResponse()) {
+            $response = $e->getResponse();
+            $status = $response->getStatusCode();
+            $body = (string) $response->getBody();
+
+            // Salesforce's documented "try again" response on the OAuth endpoint.
+            if ($status === 400 && str_contains($body, '"unknown_error"')) {
+                return true;
+            }
+
+            return $status >= 500;
+        }
+
+        return false;
+    }
+
+    /**
+     * Sleep with exponential backoff plus jitter between retry attempts.
+     */
+    protected function sleepBetweenAttempts(int $attempt, int $baseDelayMs): void
+    {
+        if ($baseDelayMs <= 0) {
+            return;
+        }
+
+        $backoff = $baseDelayMs * (2 ** ($attempt - 1));
+        $jitter = random_int(0, $baseDelayMs);
+
+        usleep(($backoff + $jitter) * 1000);
+    }
+
+    /**
+     * Lock key scoped to the connected app so multiple Salesforce orgs
+     * don't share the same lock.
+     */
+    protected function lockKey(): string
+    {
+        $consumerKey = (string) config('forrest.credentials.consumerKey', '');
+        $suffix = $consumerKey !== '' ? ':' . sha1($consumerKey) : '';
+
+        return 'salesforce:auth:lock' . $suffix;
+    }
+
+    protected function retryAttempts(): int
+    {
+        return (int) config('eloquent-salesforce-objects.authentication.retry_attempts', 3);
+    }
+
+    protected function retryBaseDelayMs(): int
+    {
+        return (int) config('eloquent-salesforce-objects.authentication.retry_base_delay_ms', 250);
+    }
+
+    protected function lockWaitSeconds(): int
+    {
+        return (int) config('eloquent-salesforce-objects.authentication.lock_wait_seconds', 8);
+    }
+
+    protected function lockTtlSeconds(): int
+    {
+        return (int) config('eloquent-salesforce-objects.authentication.lock_ttl_seconds', 10);
     }
 }

--- a/tests/Unit/ApexRestTest.php
+++ b/tests/Unit/ApexRestTest.php
@@ -402,8 +402,9 @@ describe('apexRest method', function () {
         });
 
         it('throws authentication exception when not authenticated', function () {
+            // Called twice: outer fast-path check + inner double-check inside the auth lock.
             Forrest::shouldReceive('hasToken')
-                ->once()
+                ->twice()
                 ->andReturn(false);
 
             Forrest::shouldReceive('authenticate')

--- a/tests/Unit/AuthenticationManagerTest.php
+++ b/tests/Unit/AuthenticationManagerTest.php
@@ -2,14 +2,24 @@
 
 use Daikazu\EloquentSalesforceObjects\Exceptions\AuthenticationException;
 use Daikazu\EloquentSalesforceObjects\Support\AuthenticationManager;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use Omniphx\Forrest\Providers\Laravel\Facades\Forrest;
 
 beforeEach(function () {
-    // Mock the Forrest service in the container
     $forrestMock = Mockery::mock('Omniphx\Forrest\Interfaces\StorageInterface');
     $this->app->instance('forrest', $forrestMock);
 
     Forrest::swap($forrestMock);
+
+    // Keep tests fast — no actual sleep between retries.
+    config()->set('eloquent-salesforce-objects.authentication.retry_base_delay_ms', 0);
+    config()->set('eloquent-salesforce-objects.authentication.retry_attempts', 3);
+    config()->set('eloquent-salesforce-objects.authentication.lock_wait_seconds', 5);
+    config()->set('eloquent-salesforce-objects.authentication.lock_ttl_seconds', 10);
 
     $this->manager = new AuthenticationManager;
 });
@@ -17,6 +27,28 @@ beforeEach(function () {
 afterEach(function () {
     Mockery::close();
 });
+
+/**
+ * Build a Guzzle ClientException for the documented Salesforce
+ * "unknown_error / retry your request" 400 response.
+ */
+function transientSalesforceAuthException(): ClientException
+{
+    return new ClientException(
+        'Client error',
+        new Request('POST', 'https://login.salesforce.com/services/oauth2/token'),
+        new Response(400, [], '{"error":"unknown_error","error_description":"retry your request"}')
+    );
+}
+
+function permanentSalesforceAuthException(): ClientException
+{
+    return new ClientException(
+        'Client error',
+        new Request('POST', 'https://login.salesforce.com/services/oauth2/token'),
+        new Response(400, [], '{"error":"invalid_grant","error_description":"authentication failure"}')
+    );
+}
 
 describe('ensureAuthenticated', function () {
     it('does not authenticate when token exists', function () {
@@ -30,8 +62,10 @@ describe('ensureAuthenticated', function () {
     });
 
     it('authenticates when no token exists', function () {
+        // First call: outer fast-path check (returns false).
+        // Second call: double-check inside the lock (still false).
         Forrest::shouldReceive('hasToken')
-            ->once()
+            ->twice()
             ->andReturn(false);
 
         Forrest::shouldReceive('authenticate')
@@ -40,9 +74,113 @@ describe('ensureAuthenticated', function () {
         $this->manager->ensureAuthenticated();
     });
 
-    it('throws AuthenticationException when authentication fails', function () {
+    it('skips authenticate when another worker populated the token during lock acquisition', function () {
+        // Outer check sees no token, but by the time we hold the lock,
+        // another worker has finished authenticating.
         Forrest::shouldReceive('hasToken')
+            ->twice()
+            ->andReturn(false, true);
+
+        Forrest::shouldNotReceive('authenticate');
+
+        $this->manager->ensureAuthenticated();
+    });
+
+    it('throws AuthenticationException after exhausting retries on transient errors', function () {
+        Forrest::shouldReceive('hasToken')
+            ->twice()
+            ->andReturn(false);
+
+        Forrest::shouldReceive('authenticate')
+            ->times(3)
+            ->andThrow(transientSalesforceAuthException());
+
+        expect(fn () => $this->manager->ensureAuthenticated())
+            ->toThrow(AuthenticationException::class);
+    });
+
+    it('retries on transient Salesforce unknown_error and succeeds', function () {
+        Forrest::shouldReceive('hasToken')
+            ->twice()
+            ->andReturn(false);
+
+        Forrest::shouldReceive('authenticate')
+            ->times(2)
+            ->andReturnUsing(function () {
+                static $calls = 0;
+                $calls++;
+                if ($calls === 1) {
+                    throw transientSalesforceAuthException();
+                }
+            });
+
+        $this->manager->ensureAuthenticated();
+    });
+
+    it('retries on connection errors', function () {
+        Forrest::shouldReceive('hasToken')
+            ->twice()
+            ->andReturn(false);
+
+        $connectException = new ConnectException(
+            'Connection refused',
+            new Request('POST', 'https://login.salesforce.com/services/oauth2/token')
+        );
+
+        Forrest::shouldReceive('authenticate')
+            ->times(2)
+            ->andReturnUsing(function () use ($connectException) {
+                static $calls = 0;
+                $calls++;
+                if ($calls === 1) {
+                    throw $connectException;
+                }
+            });
+
+        $this->manager->ensureAuthenticated();
+    });
+
+    it('retries on 5xx server errors', function () {
+        Forrest::shouldReceive('hasToken')
+            ->twice()
+            ->andReturn(false);
+
+        $serverException = new ServerException(
+            'Server error',
+            new Request('POST', 'https://login.salesforce.com/services/oauth2/token'),
+            new Response(503, [], 'Service Unavailable')
+        );
+
+        Forrest::shouldReceive('authenticate')
+            ->times(2)
+            ->andReturnUsing(function () use ($serverException) {
+                static $calls = 0;
+                $calls++;
+                if ($calls === 1) {
+                    throw $serverException;
+                }
+            });
+
+        $this->manager->ensureAuthenticated();
+    });
+
+    it('does not retry on permanent invalid_grant errors', function () {
+        Forrest::shouldReceive('hasToken')
+            ->twice()
+            ->andReturn(false);
+
+        // Should be called exactly once — no retry on permanent failure.
+        Forrest::shouldReceive('authenticate')
             ->once()
+            ->andThrow(permanentSalesforceAuthException());
+
+        expect(fn () => $this->manager->ensureAuthenticated())
+            ->toThrow(AuthenticationException::class);
+    });
+
+    it('does not retry on generic non-network errors', function () {
+        Forrest::shouldReceive('hasToken')
+            ->twice()
             ->andReturn(false);
 
         Forrest::shouldReceive('authenticate')
@@ -55,14 +193,29 @@ describe('ensureAuthenticated', function () {
 });
 
 describe('forceReauthenticate', function () {
-    it('always calls authenticate', function () {
+    it('always calls authenticate without checking token cache', function () {
+        // No hasToken expectations — force should bypass the cache.
         Forrest::shouldReceive('authenticate')
             ->once();
 
         $this->manager->forceReauthenticate();
     });
 
-    it('throws AuthenticationException when authentication fails', function () {
+    it('retries transient errors during forced re-authentication', function () {
+        Forrest::shouldReceive('authenticate')
+            ->times(2)
+            ->andReturnUsing(function () {
+                static $calls = 0;
+                $calls++;
+                if ($calls === 1) {
+                    throw transientSalesforceAuthException();
+                }
+            });
+
+        $this->manager->forceReauthenticate();
+    });
+
+    it('throws AuthenticationException when authentication fails permanently', function () {
         Forrest::shouldReceive('authenticate')
             ->once()
             ->andThrow(new RuntimeException('Auth failed'));
@@ -89,7 +242,7 @@ describe('getInstanceUrl', function () {
 
     it('authenticates before getting URL if no token', function () {
         Forrest::shouldReceive('hasToken')
-            ->once()
+            ->twice()
             ->andReturn(false);
 
         Forrest::shouldReceive('authenticate')
@@ -119,7 +272,7 @@ describe('getInstanceUrl', function () {
 
     it('throws exception when authentication fails', function () {
         Forrest::shouldReceive('hasToken')
-            ->once()
+            ->twice()
             ->andReturn(false);
 
         Forrest::shouldReceive('authenticate')


### PR DESCRIPTION
## Summary

Adds a resilience layer to `AuthenticationManager` to fix a production failure mode where concurrent workers all hit the Salesforce OAuth endpoint after a token-cache miss, triggering 400 `unknown_error / retry your request` responses.

- **Single-flight lock** via `Cache::lock(...)->block(...)` with a double-check inside the lock. Concurrent callers reuse the freshly-cached token instead of all issuing parallel OAuth POSTs.
- **Selective retry** with exponential backoff + jitter on transient errors only:
  - Salesforce `unknown_error / retry your request` 400 envelope
  - HTTP 5xx
  - Guzzle `ConnectException`
- **Fails fast** on `invalid_grant`, credential failures, and other 4xx — retrying those just makes things worse.
- Lock key scoped per connected app via `sha1(consumer_key)` so multi-org setups don't collide.

## New config (all env-tunable, defaults conservative)

```php
'authentication' => [
    'retry_attempts'      => env('SALESFORCE_AUTH_RETRY_ATTEMPTS', 3),
    'retry_base_delay_ms' => env('SALESFORCE_AUTH_RETRY_BASE_DELAY_MS', 250),
    'lock_wait_seconds'   => env('SALESFORCE_AUTH_LOCK_WAIT_SECONDS', 8),
    'lock_ttl_seconds'    => env('SALESFORCE_AUTH_LOCK_TTL_SECONDS', 10),
],
```

## Behavior note (non-breaking)

On cache miss, `Forrest::hasToken()` is now called twice (outer fast-path + double-check inside the lock). The hot path (token already cached) is unchanged — still a single `hasToken()` call. Tests that mocked `hasToken()` with `->once()` for the cache-miss path need to be updated to `->twice()`.

## Test plan

- [x] Unit tests for lock double-check, transient retry, permanent fail-fast, retry exhaustion, `forceReauthenticate` semantics — 18 new assertions covering all branches
- [x] Pre-existing `ApexRestTest` mock count updated for the new double-check
- [x] Full suite: **482 passed** (1207 assertions), 0 failures
- [x] `vendor/bin/pint --dirty` clean
- [x] Docs updated: `CHANGELOG.md`, `docs/configuration.md`, `docs/troubleshooting.md`

## Files changed

- `src/Support/AuthenticationManager.php` — core change
- `config/eloquent-salesforce-objects.php` — new `authentication` block
- `tests/Unit/AuthenticationManagerTest.php` — expanded test coverage
- `tests/Unit/ApexRestTest.php` — mock count update for double-check
- `CHANGELOG.md`, `docs/configuration.md`, `docs/troubleshooting.md` — docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)